### PR TITLE
fix: reorder delivery URLs to prevent router catch-all from matching geolocate endpoint

### DIFF
--- a/code/backend/apps/delivery/urls.py
+++ b/code/backend/apps/delivery/urls.py
@@ -8,5 +8,6 @@ router.register("zones", DeliveryZoneViewSet, basename="delivery-zone")
 router.register("slots", DeliverySlotViewSet, basename="delivery-slot")
 router.register("", DeliveryViewSet, basename="delivery")
 
-urlpatterns = router.urls
-urlpatterns += [path("geolocate/", GeolocateZoneView.as_view(), name="delivery-geolocate")]
+urlpatterns = [
+    path("geolocate/", GeolocateZoneView.as_view(), name="delivery-geolocate"),
+] + router.urls


### PR DESCRIPTION
The empty-prefix DeliveryViewSet registration created a {pk}/ detail route that matched 'geolocate/' before the explicit path, causing 403 Forbidden on POST requests. Moving the explicit path first ensures correct routing.