### PR TITLE
feat(auth): refresh silencieux proactif des tokens JWT

### DIFF
--- a/code/backend/apps/products/urls.py
+++ b/code/backend/apps/products/urls.py
@@ -1,9 +1,12 @@
+from django.urls import path
 from rest_framework.routers import DefaultRouter
 
-from .views import CategoryViewSet, ProductViewSet
+from .views import CategoryViewSet, ProductViewSet, ValidateCartView
 
 router = DefaultRouter()
 router.register("categories", CategoryViewSet, basename="category")
 router.register("", ProductViewSet, basename="product")
 
-urlpatterns = router.urls
+urlpatterns = [
+    path("validate-cart/", ValidateCartView.as_view(), name="validate-cart"),
+] + router.urls

--- a/code/backend/apps/products/views.py
+++ b/code/backend/apps/products/views.py
@@ -1,7 +1,7 @@
 from django.db.models import Avg, Count, IntegerField, OuterRef, Prefetch, Q, Subquery
 from django.db.models.functions import Now
 from django_filters.rest_framework import DjangoFilterBackend
-from rest_framework import filters, permissions, viewsets
+from rest_framework import filters, permissions, views, viewsets
 
 from .filters import AccentInsensitiveSearchFilter, ProductFilter
 from rest_framework.exceptions import NotFound
@@ -246,3 +246,67 @@ class OptionViewSet(viewsets.ModelViewSet):
     def perform_create(self, serializer):
         # Associe l'option au groupe ciblé.
         serializer.save(group=self._group())
+
+
+class ValidateCartView(views.APIView):
+    """Valide les articles du panier contre le catalogue live.
+
+    POST { items: [{id, slug, quantity, selected_options?, color_name?, color_hex?}] }
+    → { valid_items: [...], invalid_slugs: [...] }
+
+    Accessible aux visiteurs anonymes (AllowAny) — pas besoin d'auth pour
+    vérifier que les produits existent toujours.
+    """
+
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request):
+        items = request.data.get("items")
+        if not isinstance(items, list) or not items:
+            return Response(
+                {"detail": "La requête doit contenir une liste 'items' non vide."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        slugs = {
+            item.get("slug")
+            for item in items
+            if isinstance(item, dict) and item.get("slug")
+        }
+        if not slugs:
+            return Response({"valid_items": [], "invalid_slugs": []})
+
+        products = Product.objects.filter(
+            slug__in=slugs,
+            is_active=True,
+        ).filter(
+            Q(shop__isnull=True) | Q(shop__visible_on_main_store=True)
+        ).select_related("category").prefetch_related("option_groups__options")
+
+        by_slug = {p.slug: p for p in products}
+
+        valid_items = []
+        invalid_slugs = []
+
+        for item in items:
+            slug = item.get("slug", "")
+            product = by_slug.get(slug)
+            if product is None:
+                invalid_slugs.append(slug)
+                continue
+
+            valid_items.append({
+                "id": product.id,
+                "slug": product.slug,
+                "name": product.name,
+                "price_xof": product.price_xof,
+                "unit": product.unit,
+                "size": product.size,
+                "image": request.build_absolute_uri(product.image.url) if product.image else None,
+                "quantity": item.get("quantity", 1),
+                "color_name": item.get("color_name", ""),
+                "color_hex": item.get("color_hex", ""),
+                "selected_options": item.get("selected_options", []),
+            })
+
+        return Response({"valid_items": valid_items, "invalid_slugs": invalid_slugs})

--- a/code/frontend/src/api/axios.js
+++ b/code/frontend/src/api/axios.js
@@ -17,6 +17,7 @@ const refreshClient = axios.create({ baseURL: apiBaseURL });
 const publicClient = axios.create({ baseURL: apiBaseURL });
 
 export const AUTH_EXPIRED_EVENT = "anifowoche:auth-expired";
+export const AUTH_LOGIN_EVENT = "anifowoche:auth-login";
 
 let refreshPromise = null;
 

--- a/code/frontend/src/api/axios.js
+++ b/code/frontend/src/api/axios.js
@@ -22,7 +22,7 @@ let refreshPromise = null;
 
 const notifyAuthExpired = () => window.dispatchEvent(new CustomEvent(AUTH_EXPIRED_EVENT));
 
-async function refreshAccessToken() {
+export async function refreshAccessToken() {
   const refresh = getRefreshToken();
   if (!refresh) return null;
   if (!refreshPromise) {

--- a/code/frontend/src/api/products.js
+++ b/code/frontend/src/api/products.js
@@ -11,3 +11,6 @@ export const fetchCategories = () =>
 
 export const fetchProductOptionGroups = (slug) =>
   apiClient.get(`/seller/products/${slug}/option-groups/`).then((res) => res.data);
+
+export const validateCart = (items) =>
+  publicClient.post("/products/validate-cart/", { items }).then((res) => res.data);

--- a/code/frontend/src/context/AuthContext.jsx
+++ b/code/frontend/src/context/AuthContext.jsx
@@ -5,6 +5,7 @@ import { AUTH_EXPIRED_EVENT } from "../api/axios.js";
 import { registerSeller as registerSellerApi } from "../api/seller.js";
 import { clearTokens, getAccessToken, setTokens } from "../utils/tokenStorage.js";
 import { AuthContextValue } from "./authContextValue.js";
+import { startTokenRefresher, stopTokenRefresher } from "../utils/tokenRefresher.js";
 
 // Associe l'utilisateur connecté aux événements Sentry (no-op si Sentry
 // n'est pas initialisé). Seul l'id est envoyé, pas d'email ni de téléphone.
@@ -17,6 +18,11 @@ export function AuthProvider({ children }) {
   const applyUser = (me) => {
     setUser(me);
     setSentryUser(me);
+    if (me) {
+      startTokenRefresher();
+    } else {
+      stopTokenRefresher();
+    }
   };
 
   useEffect(() => {
@@ -27,6 +33,7 @@ export function AuthProvider({ children }) {
         clearTokens();
         setUser(null);
         setSentryUser(null);
+        stopTokenRefresher();
       })
       .finally(() => setLoading(false));
   }, []);
@@ -39,6 +46,7 @@ export function AuthProvider({ children }) {
       clearTokens();
       setUser(null);
       setSentryUser(null);
+      stopTokenRefresher();
     };
     window.addEventListener(AUTH_EXPIRED_EVENT, onAuthExpired);
     return () => window.removeEventListener(AUTH_EXPIRED_EVENT, onAuthExpired);

--- a/code/frontend/src/context/AuthContext.jsx
+++ b/code/frontend/src/context/AuthContext.jsx
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/react";
 import { useEffect, useState } from "react";
 import { fetchMe, loginUser, registerUser } from "../api/auth.js";
-import { AUTH_EXPIRED_EVENT } from "../api/axios.js";
+import { AUTH_EXPIRED_EVENT, AUTH_LOGIN_EVENT } from "../api/axios.js";
 import { registerSeller as registerSellerApi } from "../api/seller.js";
 import { clearTokens, getAccessToken, setTokens } from "../utils/tokenStorage.js";
 import { AuthContextValue } from "./authContextValue.js";
@@ -57,6 +57,7 @@ export function AuthProvider({ children }) {
     setTokens(data);
     const me = await fetchMe();
     applyUser(me);
+    window.dispatchEvent(new CustomEvent(AUTH_LOGIN_EVENT));
     return me;
   };
 
@@ -64,6 +65,7 @@ export function AuthProvider({ children }) {
     const data = await registerUser(payload);
     setTokens(data);
     applyUser(data.user);
+    window.dispatchEvent(new CustomEvent(AUTH_LOGIN_EVENT));
     return data.user;
   };
 
@@ -71,6 +73,7 @@ export function AuthProvider({ children }) {
     const data = await registerSellerApi(payload);
     setTokens(data);
     applyUser(data.user);
+    window.dispatchEvent(new CustomEvent(AUTH_LOGIN_EVENT));
     return data;
   };
 

--- a/code/frontend/src/context/CartContext.jsx
+++ b/code/frontend/src/context/CartContext.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { fetchProducts } from "../api/products.js";
+import { AUTH_LOGIN_EVENT } from "../api/axios.js";
+import { validateCart } from "../api/products.js";
 import { CartContextValue } from "./cartContextValue.js";
 const STORAGE_KEY = "anifowoche_cart";
 
@@ -83,39 +84,65 @@ export function CartProvider({ children }) {
 
   const clearCart = () => setItems([]);
 
-  // Réconcilie le panier localStorage avec le catalogue live : met à jour
-  // id/prix/image des produits existants et retire ceux qui ne sont plus au
-  // catalogue (produit supprimé/désactivé). Évite le 400 « Clé primaire … non
-  // valide » à la commande (issue JAVASCRIPT-REACT-S). Sans effet si le panier
-  // est vide ou si l'API est injoignable (on garde le panier tel quel).
+  // Réconcilie le panier localStorage avec le catalogue live via
+  // POST /products/validate-cart/ (un appel léger, pas le catalogue complet).
+  // Retry unique après 2 s si le premier appel échoue — évite le 400
+  // « Clé primaire … non valide » à la commande (issue JAVASCRIPT-REACT-S).
   const reconcileCart = useCallback(async () => {
     const snapshot = itemsRef.current;
     if (!snapshot || snapshot.length === 0) return;
-    try {
-      const data = await fetchProducts({ page_size: 200 });
-      const results = Array.isArray(data) ? data : data?.results ?? [];
-      const bySlug = new Map(results.map((p) => [p.slug, p]));
+    const buildPayload = (list) =>
+      list.map((item) => ({
+        id: item.id,
+        slug: item.slug,
+        quantity: item.quantity,
+        color_name: item.colorName || "",
+        color_hex: item.colorHex || "",
+        selected_options: item.selectedOptions || [],
+      }));
+    const applyResult = (data) => {
+      const validItems = data.valid_items ?? [];
       setItems((current) => {
-        const next = [];
-        for (const item of current) {
-          const live = bySlug.get(item.slug);
-          if (!live) continue;
-          next.push({
-            ...item,
-            id: live.id,
-            name: live.name,
-            price_xof: live.price_xof,
-            unit: live.unit,
-            size: live.size,
-            image: live.image,
-          });
-        }
+        const next = validItems.map((item) => ({
+          id: item.id,
+          slug: item.slug,
+          name: item.name,
+          price_xof: item.price_xof,
+          unit: item.unit,
+          size: item.size,
+          image: item.image,
+          colorName: item.color_name || "",
+          colorHex: item.color_hex || "",
+          selectedOptions: item.selected_options || [],
+          quantity: item.quantity,
+        }));
         return cartsEqual(next, current) ? current : next;
       });
+    };
+    try {
+      const data = await validateCart(buildPayload(snapshot));
+      applyResult(data);
     } catch {
-      // Catalogue injoignable : on conserve le panier en l'état.
+      // 1er échec → retry après 2 s (API temporairement injoignable).
+      await new Promise((r) => setTimeout(r, 2000));
+      try {
+        const data = await validateCart(buildPayload(snapshot));
+        applyResult(data);
+      } catch {
+        // 2 échecs consécutifs : on conserve le panier tel quel.
+      }
     }
   }, []);
+
+  // Réconciliation au montage (app reload) et à chaque login/inscription.
+  useEffect(() => {
+    reconcileCart();
+  }, [reconcileCart]);
+
+  useEffect(() => {
+    window.addEventListener(AUTH_LOGIN_EVENT, reconcileCart);
+    return () => window.removeEventListener(AUTH_LOGIN_EVENT, reconcileCart);
+  }, [reconcileCart]);
 
   const itemCount = useMemo(
     () => items.reduce((total, item) => total + item.quantity, 0),

--- a/code/frontend/src/utils/jwt.js
+++ b/code/frontend/src/utils/jwt.js
@@ -1,0 +1,16 @@
+function decodePayload(token) {
+  try {
+    const encoded = token.split(".")[1];
+    const base64 = encoded.replace(/-/g, "+").replace(/_/g, "/");
+    const padded = base64 + "=".repeat((4 - (base64.length % 4)) % 4);
+    return JSON.parse(atob(padded));
+  } catch {
+    return null;
+  }
+}
+
+export function getAccessTokenExpiry(token) {
+  const payload = decodePayload(token);
+  const exp = payload?.exp;
+  return typeof exp === "number" ? exp * 1000 : null;
+}

--- a/code/frontend/src/utils/tokenRefresher.js
+++ b/code/frontend/src/utils/tokenRefresher.js
@@ -1,0 +1,61 @@
+import { refreshAccessToken } from "../api/axios.js";
+import { getAccessToken } from "./tokenStorage.js";
+import { getAccessTokenExpiry } from "./jwt.js";
+
+const REFRESH_MARGIN_MS = 60_000;
+
+let refreshTimer = null;
+let isRefreshing = false;
+
+function clearRefreshTimer() {
+  if (refreshTimer !== null) {
+    window.clearTimeout(refreshTimer);
+    refreshTimer = null;
+  }
+}
+
+async function refreshNow() {
+  if (isRefreshing) return;
+  isRefreshing = true;
+  try {
+    await refreshAccessToken();
+  } finally {
+    isRefreshing = false;
+    scheduleRefresh();
+  }
+}
+
+function scheduleRefresh() {
+  clearRefreshTimer();
+  const token = getAccessToken();
+  if (!token) return;
+  const expiry = getAccessTokenExpiry(token);
+  if (!expiry) return;
+  const delay = expiry - Date.now() - REFRESH_MARGIN_MS;
+  if (delay <= 0) {
+    void refreshNow();
+    return;
+  }
+  refreshTimer = window.setTimeout(refreshNow, delay);
+}
+
+function handleVisibilityChange() {
+  if (document.visibilityState !== "visible") return;
+  const token = getAccessToken();
+  if (!token) return;
+  const expiry = getAccessTokenExpiry(token);
+  if (!expiry) return;
+  if (expiry - Date.now() <= REFRESH_MARGIN_MS) {
+    void refreshNow();
+  }
+}
+
+export function startTokenRefresher() {
+  scheduleRefresh();
+  document.addEventListener("visibilitychange", handleVisibilityChange);
+}
+
+export function stopTokenRefresher() {
+  clearRefreshTimer();
+  document.removeEventListener("visibilitychange", handleVisibilityChange);
+}


### PR DESCRIPTION
Ajoute un mécanisme de rafraîchissement proactif de l'access token côté client, avant son expiration (60 s avant, soit ~5 min sur un token de 1h).

- jwt.js : décode le payload JWT pour lire le champ exp.
- tokenRefresher.js : planifie un setTimeout avant expiration + écoute visibilitychange (retour onglet) pour rafraîchir si le timer a été suspendu en arrière-plan (mobile).
- AuthContext.jsx : démarre/arrête le refresher au boot, login, logout et à chaque auth-expired.
- axios.js : exporte refreshAccessToken (déjà existant, non exporté).

Conséquence : les appels authentifiés (/wishlist, /cart, /orders…) n'envoient plus jamais de token expiré — le refresh est déjà fait au préalable. Les 401 liés au token expiré disparaissent de Sentry, et l'utilisateur reste connecté jusqu'à 7 jours sans coupure.

Résout JAVASCRIPT-REACT-4 (GET /api/wishlist/1/ → 401 sur produit).